### PR TITLE
Add support for loading multiple configuration files.

### DIFF
--- a/lib/requirejs.js
+++ b/lib/requirejs.js
@@ -411,16 +411,8 @@ function _initPackage(pkg, pkgs) {
         return false;
       }
     }
-    var configFiles = [];
-    if(pkg.bedrock.config instanceof Array) {
-      configFiles = pkg.bedrock.config.map(function(fileName) {
-        return path.resolve(pkg.path, fileName);
-      });
-    } else {
-      configFiles.push(path.resolve(pkg.path, pkg.bedrock.config));
-    }
-    configFiles.forEach(function(file) {
-      require(file)(bedrock);
+    [].concat(pkg.bedrock.config).forEach(function(file) {
+      require(path.resolve(pkg.path, file))(bedrock);
     });
     return true;
   };

--- a/lib/requirejs.js
+++ b/lib/requirejs.js
@@ -411,8 +411,18 @@ function _initPackage(pkg, pkgs) {
         return false;
       }
     }
-    var configFile = path.resolve(pkg.path, pkg.bedrock.config);
-    require(configFile)(bedrock);
+    var configFiles = [];
+    if(pkg.bedrock.config instanceof Array) {
+      for(var i = 0; i < pkg.bedrock.config.length; ++i) {
+        configFiles.push(path.resolve(pkg.path, pkg.bedrock.config[i]));
+      }
+    } else {
+      configFiles.push(path.resolve(pkg.path, pkg.bedrock.config));
+    }
+    for(var i = 0; i < configFiles.length; ++i) {
+      var configFile = configFiles[i];
+      require(configFile)(bedrock);
+    }
     return true;
   };
 

--- a/lib/requirejs.js
+++ b/lib/requirejs.js
@@ -413,16 +413,15 @@ function _initPackage(pkg, pkgs) {
     }
     var configFiles = [];
     if(pkg.bedrock.config instanceof Array) {
-      for(var i = 0; i < pkg.bedrock.config.length; ++i) {
-        configFiles.push(path.resolve(pkg.path, pkg.bedrock.config[i]));
-      }
+      configFiles = pkg.bedrock.config.map(function(fileName) {
+        return path.resolve(pkg.path, fileName);
+      });
     } else {
       configFiles.push(path.resolve(pkg.path, pkg.bedrock.config));
     }
-    for(var i = 0; i < configFiles.length; ++i) {
-      var configFile = configFiles[i];
-      require(configFile)(bedrock);
-    }
+    configFiles.forEach(function(file) {
+      require(file)(bedrock);
+    });
     return true;
   };
 


### PR DESCRIPTION
Allows a module to load in multiple configuration files in its bedrock.json, i.e the `config:` field can now take an array of file paths.
